### PR TITLE
商品一覧表示機能first commit

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.includes(:user)
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,10 +3,11 @@ class Item < ApplicationRecord
     validates :title
     validates :content
     validates :image
-    validates :price , numericality: { greater_than: 299,less_than: 10000000}, format: { with: /\A\d+\z/, message: '半角数字を使用してください' }
+    validates :price, numericality: { greater_than: 299, less_than: 10_000_000 },
+                      format: { with: /\A\d+\z/, message: '半角数字を使用してください' }
   end
 
-    with_options presence: true, numericality: { other_than: 1 } do
+  with_options presence: true, numericality: { other_than: 1 } do
     validates :category_id
     validates :item_condition_id
     validates :shipping_cost_id
@@ -14,13 +15,13 @@ class Item < ApplicationRecord
     validates :shipping_day_id
   end
 
+  has_one_attached :image
+  belongs_to :user
+
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
   belongs_to :shipping_cost
   belongs_to_active_hash :prefecture
   belongs_to :shipping_day
   belongs_to :item_condition
-  belongs_to :user
-  has_one_attached :image
-
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,10 +127,11 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <div class='item-img-content'>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +154,7 @@
         </div>
         <% end %>
       </li>
+       <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -159,6 +159,7 @@
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+    <% if item = nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,6 +179,7 @@
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+     <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,13 +2,12 @@ FactoryBot.define do
   factory :item do
     title { Faker::Lorem.sentence }
     content { Faker::Lorem.sentence }
-    category_id {1}
-    item_condition_id {1}
-    shipping_cost_id {1}
-    prefecture_id {1}
-    shipping_day_id {1}
+    category_id { 1 }
+    item_condition_id { 1 }
+    shipping_cost_id { 1 }
+    prefecture_id { 1 }
+    shipping_day_id { 1 }
     price { Faker::Lorem.sentence }
-    
 
     association :user
     after(:build) do |item|

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Item, type: :model do
       it 'priceが半角数字のみしか登録できない' do
         @item.price = 'aaaaaa'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'priceが全角文字では登録できない' do
         @item.price = 'AAAAAA'
@@ -81,39 +81,39 @@ RSpec.describe Item, type: :model do
       it 'priceは¥299以下では登録できない' do
         @item.price = '299'
         @item.valid?
-        
+
         expect(@item.errors.full_messages).to include('Price must be greater than 299')
       end
       it 'priceは¥10000000以上では登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than 10000000')
       end
-        it 'shipping_cost_idのidが1では登録できない' do
-          @item.shipping_day_id = 1
-          @item.valid?
-          expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
+      it 'shipping_cost_idのidが1では登録できない' do
+        @item.shipping_day_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
       end
       it 'category_idのidが1では登録できない' do
         @item.category_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Category must be other than 1')
-    end
+      end
       it 'prefecture_idのidが1では登録できない' do
         @item.prefecture_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
-    end
+      end
       it 'item_condition_idのidが1では登録できない' do
-      @item.item_condition_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Item condition must be other than 1')
-    end
+        @item.item_condition_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Item condition must be other than 1')
+      end
       it 'shipping_day_idのidが1では登録できない' do
-      @item.shipping_day_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
-      end 
+        @item.shipping_day_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
+      end
     end
   end
 end


### PR DESCRIPTION
# what
トップページに一覧表示機能を実装しました。
# why
トップページに一覧表示をすることでページを見やすくしました。

・商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/9710c1a78bbcd098789c0938dc5fef05
・商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/fac7f0a0f6f6437cfcc9def095b80dab