### PR TITLE
商品情報編集機能　first commit

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :set_item, except: [:index, :new, :create]
+  before_action :contributor_confirmation, only: [:edit, :update]
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_index, except: [:index, :show]
 
@@ -20,12 +22,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
-    redirect_to action: :index unless @item.user_id == current_user.id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
@@ -34,7 +33,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   private
@@ -42,6 +40,14 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:title, :content, :image, :price, :category_id, :item_condition_id, :shipping_cost_id, :prefecture_id,
                                  :shipping_day_id).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def contributor_confirmation
+    redirect_to action: :index unless @item.user_id == current_user.id
   end
 
   def move_to_index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,8 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, except: [:index, :new, :create]
   before_action :contributor_confirmation, only: [:edit, :update]
-  before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, except: [:index, :show]
-
+  
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -50,7 +49,4 @@ class ItemsController < ApplicationController
     redirect_to action: :index unless @item.user_id == current_user.id
   end
 
-  def move_to_index
-    redirect_to action: :index unless user_signed_in?
-  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -18,18 +19,19 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def edit
-  #   @item = Item.find(params[:id])
-  # end
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to action: :index unless @item.user_id == current_user.id
+  end
 
-  # def update
-  #   @item = Item.find(params[:id])
-  #   if item.update(item_params)
-  #     redirect_to item_path(@item)
-  #   else
-  #     render :edit
-  #   end
-  # end
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
+    end
+  end
 
   def show
     @item = Item.find(params[:id])
@@ -40,5 +42,9 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:title, :content, :image, :price, :category_id, :item_condition_id, :shipping_cost_id, :prefecture_id,
                                  :shipping_day_id).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    redirect_to action: :index unless user_signed_in?
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item) , class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%# <%= form_with model: @item, local: true do |f| %> %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# <%= render 'shared/error_messages', model: f.object %> %>
-
+    <%= render "shared/error_messages", model: f.object %>
+    
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -21,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%# <%= f.file_field :image, id:"image" %> %>
+        <%= f.file_field :image, id:"image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -31,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%# <%= f.text_area :title, class:"items-text", id:"title", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %> %>
+      <%= f.text_area :title, class:"items-text", id:"title", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.text_area :content, class:"items-text", id:"content", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %> %>
+        <%= f.text_area :content, class:"items-text", id:"content", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -50,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %> %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"category_id"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
-        </div>        
-       <%# <%= f.collection_select(:item_condition_id,ItemCondition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %> %>
+        </div>
+       <%= f.collection_select(:item_condition_id, ItemCondition.all, :id, :name, {}, {class:"select-box", id:"item_condition_id"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,18 +71,18 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"shipping_cost_id"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %> %>
+         <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture_id"}) %> 
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %> %>
-      </div> %>
+         <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"shipping_day_id"}) %> 
+      </div> 
     </div>
     <%# /配送について %>
 
@@ -99,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%# <%= f.text_field :price, class:"price-input", id:"price", placeholder:"例）300" %> %>
+          <%= f.text_field :price, class:"price-input", id:"price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -137,7 +137,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', root_path , class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>


### PR DESCRIPTION
# WHAT
商品情報編集機能を実装しました。
# WHY
投稿後に内容を編集できるようにするため

・ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/8d397feba7045bae060d467a9fcfbf2b
・正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/afb512e241f510efcfc01b4b0683f03b
・入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/002786839199d8a6cd0a78453f75d54a
・何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/abf10d81f10928fe26c023c0e6636cbb
・ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/c85f3629e47ccc7362b22881d88b9f19
・ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/91580c774fd3804cb420a08e7299673d
・ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
終わってません。
・商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/ae8a4738f9cad8bd9c29f2c4169b2237